### PR TITLE
Added ability to show warning messages again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ qt_add_qml_module(appDyno_Info
         assets/images/WARN.png
         assets/images/LC.png
         assets/images/lock_icon.png
+        assets/images/kachow.png
         QML_FILES TractionControl.qml
         QML_FILES BrakeBias.qml
         QML_FILES VehicleInfoDisplay.qml

--- a/InputManager.qml
+++ b/InputManager.qml
@@ -488,9 +488,34 @@ Item {
             else if (pongGame.visible) {
                 pongGame.movePaddleUp()
             }
-            else {
+            else if (columnBar.x > 0 && menuShown === true && engineInfoScreen.visible === false) {
                 counter = counter - 1
             }
+            if(menuShown === false && engineInfoScreen.visible === false) {
+                if(rootWindow.ecuFault === true) {
+                    statusImage.source = "assets/images/WARN.png"
+                    statusMessage.text = faultMessage
+                }
+                else {
+                    statusImage.source = "assets/images/kachow.png"
+                    statusMessage.text = "KACHOW!"
+                }
+                statusMessage.text.pixelSize = 20
+                animator.statusUpdateAnimation_START()
+            }
+            else if(engineInfoScreen.visible === true || extraInfoWidgets.visible === true) {
+                if(rootWindow.ecuFault === true) {
+                    statusImageAdvancedView.source = "assets/images/WARN.png"
+                    statusMessageAdvancedView.text = faultMessage
+                }
+                else {
+                    statusImageAdvancedView.source = "assets/images/kachow.png"
+                    statusMessageAdvancedView.text = "KACHOW!"
+                }
+                statusMessageAdvancedView.text.pixelSize = 20
+                animator.advancedViewStatusUpdateAnimation_START()
+            }
+
 
             if(brakeBiasScreen.visible === true && brakeBiasObject.biasVal < 100 && brakeBiasObject.rearBrakeBias > 0)
             {

--- a/Main.qml
+++ b/Main.qml
@@ -711,20 +711,36 @@ Window
             else if (event.key === Qt.Key_W) {
                 if(engineInfoScreen.visible === true)
                 {
-                    ecuFaultImage.visible = true
-                    statusImageAdvancedView.source = "assets/images/WARN.png"
-                    statusMessageAdvancedView.text = "ECU fault"
-                    statusMessageAdvancedView.text.pixelSize = 20
-                    animator.advancedViewStatusUpdateAnimation_START()
+                    if(rootWindow.ecuFault === false) {
+                        rootWindow.ecuFault = true
+                        ecuFaultImage.visible = true
+                        statusImageAdvancedView.source = "assets/images/WARN.png"
+                        rootWindow.faultMessage = "ECU fault"
+                        statusMessageAdvancedView.text = rootWindow.faultMessage
+                        statusMessageAdvancedView.text.pixelSize = 20
+                        animator.advancedViewStatusUpdateAnimation_START()
+                    }
+                    else {
+                        rootWindow.ecuFault = false
+                        ecuFaultImage.visible = false
+                    }
                 }
                 else
                 {
-                    ecuFaultImage.visible = true
-                    statusImage.source = "assets/images/WARN.png"
-                    //statusMessage.text = "ECU fault"
-                    statusMessage.text = "Engine oil pressure fault detected"
-                    statusMessage.text.pixelSize = 20
-                    animator.statusUpdateAnimation_START()
+                    if(rootWindow.ecuFault === false)
+                    {
+                        rootWindow.ecuFault = true
+                        ecuFaultImage.visible = true
+                        statusImage.source = "assets/images/WARN.png"
+                        rootWindow.faultMessage = "ECU fault"
+                        statusMessage.text = rootWindow.faultMessage
+                        statusMessage.text.pixelSize = 20
+                        animator.statusUpdateAnimation_START()
+                    }
+                    else {
+                        rootWindow.ecuFault = false
+                        ecuFaultImage.visible = false
+                    }
                 }
             }
             else if (event.key === Qt.Key_P) {


### PR DESCRIPTION
Press UP when no menu (options/game) is open to repeat the warning message, if any warnings are present.  Works in advanced view as well